### PR TITLE
chore(deps): pin pnpm version via packageManager field

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -6,8 +6,6 @@ runs:
   steps:
     - name: Install pnpm
       uses: pnpm/action-setup@v5
-      with:
-        version: latest
 
     - name: Set up Node.js
       uses: actions/setup-node@v6

--- a/.github/workflows/deploy.reusable.yml
+++ b/.github/workflows/deploy.reusable.yml
@@ -47,6 +47,8 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           NEXT_PUBLIC_MATOMO_URL: ${{ vars.NEXT_PUBLIC_MATOMO_URL }}
           NEXT_PUBLIC_MATOMO_SITE_ID: ${{ vars.NEXT_PUBLIC_MATOMO_SITE_ID }}
+          NEXT_PUBLIC_SENTRY_DSN: ${{ vars.NEXT_PUBLIC_SENTRY_DSN }}
+          SENTRY_DSN: ${{ vars.NEXT_PUBLIC_SENTRY_DSN }}
         run: |
           echo "Deploying stage: ${{ inputs.stage }}"
           DEPLOY_OUTPUT=$(pnpm sst deploy --stage "${{ inputs.stage }}")

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "",
   "type": "module",
+  "packageManager": "pnpm@11.2.2",
   "browserslist": ["> 1%", "maintained node versions", "not dead"],
   "main": "index.js",
   "scripts": {

--- a/src/configuration/telemetry/event-tracker/client/index.prod.ts
+++ b/src/configuration/telemetry/event-tracker/client/index.prod.ts
@@ -7,8 +7,8 @@ export const trackPageView = matomoBrowserPageView();
 
 export const register = (): void => {
   initMatomoBrowser({
-    url: clientEnv.NEXT_PUBLIC_MATOMO_URL || 'https://ihexa.matomo.cloud',
-    siteId: clientEnv.NEXT_PUBLIC_MATOMO_SITE_ID || '1',
+    url: clientEnv.NEXT_PUBLIC_MATOMO_URL,
+    siteId: clientEnv.NEXT_PUBLIC_MATOMO_SITE_ID,
     disableCookies: true
   });
   trackPageView();

--- a/src/configuration/telemetry/event-tracker/client/index.prod.ts
+++ b/src/configuration/telemetry/event-tracker/client/index.prod.ts
@@ -7,8 +7,8 @@ export const trackPageView = matomoBrowserPageView();
 
 export const register = (): void => {
   initMatomoBrowser({
-    url: clientEnv.NEXT_PUBLIC_MATOMO_URL,
-    siteId: clientEnv.NEXT_PUBLIC_MATOMO_SITE_ID,
+    url: clientEnv.NEXT_PUBLIC_MATOMO_URL || 'https://ihexa.matomo.cloud',
+    siteId: clientEnv.NEXT_PUBLIC_MATOMO_SITE_ID || '1',
     disableCookies: true
   });
   trackPageView();

--- a/sst.config.ts
+++ b/sst.config.ts
@@ -16,7 +16,9 @@ export default $config({
       environment: {
         DATABASE_URL: databaseUrl.value,
         NEXT_PUBLIC_MATOMO_URL: process.env['NEXT_PUBLIC_MATOMO_URL'] ?? '',
-        NEXT_PUBLIC_MATOMO_SITE_ID: process.env['NEXT_PUBLIC_MATOMO_SITE_ID'] ?? ''
+        NEXT_PUBLIC_MATOMO_SITE_ID: process.env['NEXT_PUBLIC_MATOMO_SITE_ID'] ?? '',
+        NEXT_PUBLIC_SENTRY_DSN: process.env['NEXT_PUBLIC_SENTRY_DSN'] ?? '',
+        SENTRY_DSN: process.env['SENTRY_DSN'] ?? ''
       }
     });
   }

--- a/sst.config.ts
+++ b/sst.config.ts
@@ -14,7 +14,9 @@ export default $config({
 
     new sst.aws.Nextjs('IHexa', {
       environment: {
-        DATABASE_URL: databaseUrl.value
+        DATABASE_URL: databaseUrl.value,
+        NEXT_PUBLIC_MATOMO_URL: process.env['NEXT_PUBLIC_MATOMO_URL'] ?? '',
+        NEXT_PUBLIC_MATOMO_SITE_ID: process.env['NEXT_PUBLIC_MATOMO_SITE_ID'] ?? ''
       }
     });
   }


### PR DESCRIPTION
Declare packageManager: pnpm@11.2.2 so Dependabot (and corepack/CI) use the same pnpm as the one that wrote the v9 lockfile, avoiding metadata-resolution errors (ERR_PNPM_BROKEN_METADATA_JSON) during Dependabot updates.