### PR TITLE
fix(env): read NEXT_PUBLIC_* via explicit keys for build inlining

### DIFF
--- a/src/env/env.client.ts
+++ b/src/env/env.client.ts
@@ -9,4 +9,9 @@ const ClientEnvSchema = Schema.Struct({
 
 export type ClientEnv = typeof ClientEnvSchema.Type;
 
-export const clientEnv = Schema.decodeUnknownSync(ClientEnvSchema)(process.env);
+export const clientEnv = Schema.decodeUnknownSync(ClientEnvSchema)({
+  NEXT_PUBLIC_APP_NAME: process.env['NEXT_PUBLIC_APP_NAME'],
+  NEXT_PUBLIC_SENTRY_DSN: process.env['NEXT_PUBLIC_SENTRY_DSN'],
+  NEXT_PUBLIC_MATOMO_URL: process.env['NEXT_PUBLIC_MATOMO_URL'],
+  NEXT_PUBLIC_MATOMO_SITE_ID: process.env['NEXT_PUBLIC_MATOMO_SITE_ID']
+});


### PR DESCRIPTION
Schema.decodeUnknownSync was fed the bare process.env object. Next/Turbopack only statically inlines explicit member accesses (process.env['NEXT_PUBLIC_X']), not a bare process.env reference. With env injected by SST (not the shell), the NEXT_PUBLIC_* values were never inlined, so Matomo/Sentry stayed disabled in production despite the full deploy/SST plumbing being correct.

Decode an explicit object of per-key accesses. Verified locally: with env provided via a file (not the shell), the bare form drops the values while the explicit form inlines them into the client bundle.